### PR TITLE
Retry links

### DIFF
--- a/src/components/CreateGist.js
+++ b/src/components/CreateGist.js
@@ -30,6 +30,7 @@ class CreateGist extends Component {
                 Create Gist
               </button>
               {createGistStatus.pending && 'Creating gist...'}
+              {createGistStatus.failed && 'An error occurred while creating the gist.'}
             </div>
             <div className="Gist-description">
               <div className="Gist-descriptionLabel">

--- a/src/components/Gist.js
+++ b/src/components/Gist.js
@@ -27,7 +27,11 @@ class Gist extends Component {
     return (
       <div className="Gist">
         {readGistStatus.pending && ('Loading gist...')}
-        {readGistStatus.failed && !gistNotFound && ('There was an error while retrieving this gist')}
+        {readGistStatus.failed && !gistNotFound && (
+          <span>
+            There was an error while retrieving this gist. <button onClick={this.readGist}>Try again.</button>
+          </span>
+        )}
         {readGistStatus.failed && gistNotFound && ('This gist could not be found.')}
         {readGistStatus.succeeded && (
           <form>

--- a/src/components/Gists.js
+++ b/src/components/Gists.js
@@ -16,7 +16,11 @@ class Gists extends Component {
     return (
       <div className="Gists">
         {usersGistsStatus.pending && ('Loading gists...')}
-        {usersGistsStatus.failed && ('There was an error loading gists.')}
+        {usersGistsStatus.failed && (
+          <span>
+            There was an error loading gists. <button onClick={this.fetchUsersGists}>Try again.</button>
+          </span>
+        )}
         {usersGistsStatus.succeeded && (
           <ul className="Gists-list">
             {usersGists.map(gist => (


### PR DESCRIPTION
Resolves #9 

---

Note that there are not error messages when an update/delete fail. The reason is because I have a single location to display these, so I would need to clear out the other message when a new one comes in. This is pretty app-specific logic (other apps may not place the messages in the same location), so to avoid confusion, I've left them out. I might one day add them in...but if you're reading this, be sure to always add a fail state message!